### PR TITLE
cfg rescale for batch + `AND_PERP` keyword

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -101,7 +101,7 @@ class NeutralPromptScript(scripts.Script):
             ui_enabled = gr.Checkbox(label='Enable', value=False)
             ui_cfg_rescale = gr.Slider(label='CFG rescale', minimum=0, maximum=1, value=0)
             with gr.Accordion(label='Prompt formatter', open=False):
-                neutral_prompt = gr.Textbox(label='Neutral prompt', show_label=False, lines=3, placeholder='Neutral prompt (will be added to the positive prompt textbox)')
+                neutral_prompt = gr.Textbox(label='Neutral prompt', show_label=False, lines=3, placeholder='Neutral prompt (click on apply below to append this to the positive prompt textbox)')
                 neutral_cond_scale = gr.Slider(label='Neutral CFG', minimum=-3, maximum=3, value=-1)
                 append_to_prompt = gr.Button(value='Apply to prompt')
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,16 +1,16 @@
 import torch
 from modules import scripts, processing, prompt_parser, script_callbacks, sd_samplers_kdiffusion, shared
 import gradio as gr
+import re
 
 
 is_enabled = False
-neutral_prompt = ''
-neutral_cond_scale = 1.0
+perp_profile = None
 cfg_rescale = 0
 
 
 def combine_denoise_hijack(self, x_out, conds_list, uncond, cond_scale):
-    global is_enabled, neutral_cond_scale, cfg_rescale
+    global is_enabled, cfg_rescale
     if not is_enabled:
         return original_combine_denoise(self, x_out, conds_list, uncond, cond_scale)
 
@@ -20,18 +20,18 @@ def combine_denoise_hijack(self, x_out, conds_list, uncond, cond_scale):
 
     del conds_list[0][0]
 
-    x_pos_std = 0
-
     for i, conds in enumerate(conds_list):
+        x_pos_acc = torch.zeros_like(x_uncond[i])
         for cond_index, weight in conds:
             x_pos = x_out[cond_index]
-            x_pos_std += torch.std(x_pos)
+            x_pos_acc += x_pos
             x_pos_delta = x_pos - x_uncond[i]
             x_cfg = x_pos_delta + neutral_cond_scale * get_perpendicular_component(x_pos_delta, x_neutral - x_uncond[i])
             denoised[i] += x_cfg * (weight * cond_scale)
 
-    x_cfg_std = torch.std(denoised)
-    denoised *= cfg_rescale * (x_pos_std / x_cfg_std - 1) + 1
+        x_pos_std = torch.std(x_pos_acc)
+        x_cfg_std = torch.std(denoised[i])
+        denoised[i] *= cfg_rescale * (x_pos_std / x_cfg_std - 1) + 1
 
     return denoised
 
@@ -47,16 +47,20 @@ def get_perpendicular_component(pos, neg):
 
 
 def get_multicond_learned_conditioning_hijack(model, prompts, steps):
-    global is_enabled, neutral_prompt
+    global is_enabled
     if not is_enabled:
         return original_get_multicond_learned_conditioning(model, prompts, steps)
 
-    res = original_get_multicond_learned_conditioning(model, prompts, steps)
-    res.batch[0].insert(0, prompt_parser.ComposableScheduledPromptConditioning(
-        schedules=prompt_parser.get_learned_conditioning(model, [neutral_prompt], steps)[0],
-        weight=0.
-    ))
-    return res
+    for prompt in prompts:
+        split_prompt = re.split(r'\b(AND(?:_PERP)?|^\s*PERP)\b', prompt)
+        for keyword, sub_prompt in zip(split_prompt[1::2], split_prompt[2::2]):
+            if keyword != 'AND_PERP':
+                continue
+
+
+
+    new_prompts = [re.sub(r'\bAND_PERP\b', 'AND', prompt) for prompt in prompts]
+    return original_get_multicond_learned_conditioning(model, new_prompts, steps)
 
 
 original_get_multicond_learned_conditioning = getattr(prompt_parser, '__neutral_prompt_original_get_multicond_learned_conditioning', prompt_parser.get_multicond_learned_conditioning)
@@ -89,9 +93,9 @@ class NeutralPromptScript(scripts.Script):
 
     def ui(self, is_img2img):
         with gr.Accordion(label='Neutral Prompt', open=False):
-            ui_neutral_prompt = gr.Textbox(label='Neutral prompt ', show_label=False, lines=3, placeholder='Neutral prompt')
-            ui_neutral_cond_scale = gr.Slider(label='Neutral CFG ', minimum=-3, maximum=0, value=1)
-            ui_cfg_rescale = gr.Slider(label='CFG Rescale ', minimum=0, maximum=1, value=0)
+            ui_neutral_prompt = gr.Textbox(label='Neutral prompt', show_label=False, lines=3, placeholder='Neutral prompt')
+            ui_neutral_cond_scale = gr.Slider(label='Neutral CFG', minimum=-3, maximum=0, value=1)
+            ui_cfg_rescale = gr.Slider(label='CFG Rescale', minimum=0, maximum=1, value=0)
 
         return [ui_neutral_prompt, ui_neutral_cond_scale, ui_cfg_rescale]
 


### PR DESCRIPTION
Add the `AND_PERP` keyword to allow to specify multiple neutral prompts each with their own weight.