### PR TITLE
external_code

### DIFF
--- a/lib_neutral_prompt/cfg_denoiser_hijack.py
+++ b/lib_neutral_prompt/cfg_denoiser_hijack.py
@@ -55,6 +55,7 @@ def get_webui_denoised(
 
 
 def get_cfg_rescale_factor(cfg_cond, cond):
+    global_state.apply_and_clear_cfg_rescale_override()
     return global_state.cfg_rescale * (torch.std(cond) / torch.std(cfg_cond) - 1) + 1
 
 

--- a/lib_neutral_prompt/external_code/__init__.py
+++ b/lib_neutral_prompt/external_code/__init__.py
@@ -1,0 +1,12 @@
+def fix_path():
+    import sys
+    from pathlib import Path
+
+    extension_path = str(Path(__file__).parent.parent.parent)
+    if extension_path not in sys.path:
+        sys.path.append(extension_path)
+
+
+fix_path()
+del fix_path
+from .api import *

--- a/lib_neutral_prompt/external_code/api.py
+++ b/lib_neutral_prompt/external_code/api.py
@@ -1,0 +1,5 @@
+from lib_neutral_prompt import global_state
+
+
+def override_cfg_rescale(cfg_rescale: float):
+    global_state.cfg_rescale_override = cfg_rescale

--- a/lib_neutral_prompt/global_state.py
+++ b/lib_neutral_prompt/global_state.py
@@ -1,8 +1,16 @@
-from typing import List
+from typing import List, Optional
 from lib_neutral_prompt import neutral_prompt_parser
 
 
 is_enabled: bool = False
 prompt_exprs: List[neutral_prompt_parser.PromptExpr] = []
-cfg_rescale: float = 0.
+cfg_rescale: float = 0.0
 verbose: bool = True
+cfg_rescale_override: Optional[float] = None
+
+
+def apply_and_clear_cfg_rescale_override():
+    global cfg_rescale, cfg_rescale_override
+    if cfg_rescale_override is not None:
+        cfg_rescale = cfg_rescale_override
+        cfg_rescale_override = None

--- a/scripts/neutral_prompt.py
+++ b/scripts/neutral_prompt.py
@@ -66,6 +66,7 @@ def composable_lora_process_hijack(p: processing.StableDiffusionProcessing, *arg
 
     exprs = prompt_parser_hijack.parse_prompts(p.all_prompts)
     all_prompts, p.all_prompts = p.all_prompts, prompt_parser_hijack.transpile_exprs(exprs)
-    original_function(p, *args, **kwargs)
+    res = original_function(p, *args, **kwargs)
     # restore original prompts
     p.all_prompts = all_prompts
+    return res


### PR DESCRIPTION
usage:

```python
neutral_prompt = importlib.import_module("extensions.sd-webui-neutral-prompt.lib_neutral_prompt.external_code", "external_code")

# ... later in code
neutral_prompt.override_cfg_rescale(0.5)  # or whatever value you want
```

make sure to call `neutral_prompt.override_cfg_rescale` before the first cfg denoiser call. Tested in a script `process` function, it should work no matter the script order with respect to neutral prompt.