### PR TITLE
Support stable-diffusion-webui-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Neutral prompt is an a1111 webui extension that adds alternative composable diff
 
 ## Features
 
+- Now compatible wih [stable-diffusion-webui-forge](https://github.com/lllyasviel/stable-diffusion-webui-forge)!
 - [Perp-Neg](https://perp-neg.github.io/) orthogonal prompts, invoked using the `AND_PERP` keyword
 - saliency-aware noise blending, invoked using the `AND_SALT` keyword (credits to [Magic Fusion](https://magicfusion.github.io/) for the algorithm used to determine SNB maps from epsilons)
 - semantic guidance top-k filtering, invoked using the `AND_TOPK` keyword (reference: https://arxiv.org/abs/2301.12247)

--- a/lib_neutral_prompt/cfg_denoiser_hijack.py
+++ b/lib_neutral_prompt/cfg_denoiser_hijack.py
@@ -296,8 +296,7 @@ if forge:
             args = CombineDenoiseArgs(denoised_conds.unbind(dim=1)[batch_i], denoised_uncond[batch_i], cond_indices)
             cond_delta = prompt.accept(CondDeltaVisitor(), args, 0)
             aux_cond_delta = prompt.accept(AuxCondDeltaVisitor(), args, cond_delta, 0)
-            cfg_cond = forge_denoised[batch_i] + aux_cond_delta * cond_scale
-            forge_denoised[batch_i] = cfg_rescale(cfg_cond, denoised_uncond[batch_i] + cond_delta + aux_cond_delta)
+            forge_denoised[batch_i] += aux_cond_delta * cond_scale
 
         return forge_denoised
 

--- a/lib_neutral_prompt/cfg_denoiser_hijack.py
+++ b/lib_neutral_prompt/cfg_denoiser_hijack.py
@@ -255,8 +255,8 @@ if forge:
         uncond = model_options['uncond']
 
         cond.extend(uncond)
-        remove_last_cond = (len(cond) % 2) == 1
-        if remove_last_cond:
+        discard_last = (len(cond) % 2) == 1
+        if discard_last:
             cond.append(cond[-1])
 
         for elem in cond:
@@ -268,7 +268,7 @@ if forge:
             for denoised in original_function(model, [first_cond], [second_cond], x_in, timestep, model_options)
         ]
 
-        if remove_last_cond:
+        if discard_last:
             denoised_latents = denoised_latents[:-1]
 
         # B, C, H, W

--- a/lib_neutral_prompt/ui.py
+++ b/lib_neutral_prompt/ui.py
@@ -4,6 +4,14 @@ from typing import Dict, Tuple, List, Callable
 import gradio as gr
 import dataclasses
 
+try:
+    # import a forge-specific module
+    from modules_forge import forge_sampler
+    del forge_sampler
+    forge = True
+except ImportError:
+    forge = False
+
 
 txt2img_prompt_textbox = None
 img2img_prompt_textbox = None
@@ -29,7 +37,7 @@ class AccordionInterface:
     def __post_init__(self):
         self.is_rendered = False
 
-        self.cfg_rescale = gr.Slider(label='CFG rescale', minimum=0, maximum=1, value=0)
+        self.cfg_rescale = gr.Slider(label='CFG rescale', minimum=0, maximum=1, value=0, visible=not forge, interactive=not forge)
         self.neutral_prompt = gr.Textbox(label='Neutral prompt', show_label=False, lines=3, placeholder='Neutral prompt (click on apply below to append this to the positive prompt textbox)')
         self.neutral_cond_scale = gr.Slider(label='Prompt weight', minimum=-3, maximum=3, value=1)
         self.aux_prompt_type = gr.Dropdown(label='Prompt type', choices=list(prompt_types.keys()), value=next(iter(prompt_types.keys())), tooltip=prompt_types_tooltip, elem_id=self.get_elem_id('formatter_prompt_type'))


### PR DESCRIPTION
Hijacks the forge_sample function and calls it separately for each individual text conditioning. The outputs are then recombined into a format that the extension already knows how to work with.

This doesn't use forge's patcher or take advantage of all of forge's performance optimizations brought over from ComfyUI via ldm_patched,  but it does guarantee backwards compatibility for base A1111 users, and allows Forge users to use the extension without maintaining a separate install of A1111.

For a discussion of some of the challenges of manipulating denoised latents more directly using built-in functionality of Forge, see: https://github.com/hako-mikan/sd-webui-regional-prompter/issues/299